### PR TITLE
Example for separate models for training on poisoned and cleaned datasets

### DIFF
--- a/example_models/keras/gtsrb_convnet.py
+++ b/example_models/keras/gtsrb_convnet.py
@@ -1,0 +1,59 @@
+"""
+Preprocessing and simple model architecture for German Traffic Sign Recognition Benchmark
+"""
+import numpy as np
+from PIL import Image
+import tensorflow as tf
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.layers import Dense, Conv2D, Flatten, MaxPooling2D
+from art.classifiers import KerasClassifier
+
+
+def preprocessing_fn(img):
+    img_size = 48
+    img_out = []
+    for im in img:
+        im = Image.fromarray(im)
+        im = np.array(im.resize((img_size, img_size)))
+        img_out.append(im)
+    return np.array(img_out, dtype=np.float32)
+
+
+def make_model(**kwargs) -> tf.keras.Model:
+    model = Sequential()
+    model.add(
+        Conv2D(
+            filters=4,
+            kernel_size=(5, 5),
+            strides=1,
+            activation="relu",
+            input_shape=(48, 48, 3),
+        )
+    )
+    model.add(MaxPooling2D(pool_size=(2, 2)))
+    model.add(
+        Conv2D(
+            filters=10,
+            kernel_size=(5, 5),
+            strides=1,
+            activation="relu",
+            input_shape=(22, 22, 4),
+        )
+    )
+    model.add(MaxPooling2D(pool_size=(2, 2)))
+    model.add(Flatten())
+    model.add(Dense(100, activation="relu"))
+    model.add(Dense(43, activation="softmax"))
+
+    model.compile(
+        loss=tf.keras.losses.sparse_categorical_crossentropy,
+        optimizer=tf.keras.optimizers.Adam(lr=0.003),
+        metrics=["accuracy"],
+    )
+    return model
+
+
+def get_art_model(model_kwargs, wrapper_kwargs, weights_file=None):
+    model = make_model(**model_kwargs)
+    wrapped_model = KerasClassifier(model, clip_values=(0.0, 1.0), **wrapper_kwargs)
+    return wrapped_model

--- a/example_scenario_configs/gtsrb_scenario_two_models.json
+++ b/example_scenario_configs/gtsrb_scenario_two_models.json
@@ -57,7 +57,7 @@
         "name": "GTSRB"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.9.0-dev",
+        "docker_image": "twosixarmory/tf1:0.9.0",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/example_scenario_configs/gtsrb_scenario_two_models.json
+++ b/example_scenario_configs/gtsrb_scenario_two_models.json
@@ -1,0 +1,67 @@
+{
+    "_description": "GTSRB poison image classification (two models), contributed by MITRE Corporation",
+    "adhoc": {
+        "defense_model": {
+            "fit": true,
+            "fit_kwargs": {},
+            "model_kwargs": {},
+            "module": "example_models.keras.gtsrb_convnet",
+            "name": "get_art_model",
+            "weights_file": null,
+            "wrapper_kwargs": {}
+        },
+        "defense_model_train_epochs": 10,
+        "fraction_poisoned": 0.1,
+        "np_seed": 123,
+        "poison_dataset": true,
+        "source_class": 5,
+        "target_class": 42,
+        "tf_seed": 123,
+        "train_epochs": 20,
+        "use_poison_filtering_defense": true
+    },
+    "attack": {
+        "knowledge": "black",
+        "kwargs": {
+            "poison_module": "art.attacks.poisoning.perturbations",
+            "poison_type": "pattern"
+        },
+        "module": "armory.art_experimental.attacks.poison_loader",
+        "name": "poison_loader_GTSRB"
+    },
+    "dataset": {
+        "batch_size": 512,
+        "framework": "numpy",
+        "module": "armory.data.datasets",
+        "name": "german_traffic_sign"
+    },
+    "defense": {
+        "kwargs": {},
+        "module": "art.poison_detection.activation_defence",
+        "name": "ActivationDefence",
+        "type": "PoisonFilteringDefence"
+    },
+    "metric": null,
+    "model": {
+        "fit": true,
+        "fit_kwargs": {},
+        "model_kwargs": {},
+        "module": "armory.baseline_models.keras.micronnet_gtsrb",
+        "name": "get_art_model",
+        "weights_file": null,
+        "wrapper_kwargs": {}
+    },
+    "scenario": {
+        "kwargs": {},
+        "module": "armory.scenarios.poisoning_gtsrb_scenario",
+        "name": "GTSRB"
+    },
+    "sysconfig": {
+        "docker_image": "twosixarmory/tf1:0.9.0-dev",
+        "external_github_repo": null,
+        "gpus": "all",
+        "output_dir": null,
+        "output_filename": null,
+        "use_gpu": false
+    }
+}


### PR DESCRIPTION
Note that the Armory version must be 0.9.0-dev or higher to work with the updated scenario file.