### PR TITLE
Create download data config for eval 2 nonadversarial datasets

### DIFF
--- a/scenario_download_configs/scenarios-set2.json
+++ b/scenario_download_configs/scenarios-set2.json
@@ -1,0 +1,45 @@
+{
+    "scenario": {
+        "german-traffic-sign-image-poisoning": {
+            "dataset_name": [
+                "german_traffic_sign"
+            ],
+            "weights_file": [
+                null
+            ]
+        },
+        "librispeech-asr": {
+            "dataset_name": [
+                "librispeech"
+            ],
+            "weights_file": [
+                null
+            ]
+        },
+        "so2sat-multimodal-classification": {
+            "dataset_name": [
+                "so2sat"
+            ],
+            "weights_file": [
+                "multimodal_baseline_weights.h5"
+            ]
+        },
+        "ucf-action-recognition": {
+            "dataset_name": [
+                "ucf101"
+            ],
+            "weights_file": [
+                "mars_ucf101_v1.pth",
+                "mars_kinetics_v1.pth"
+            ]
+        },
+        "xview-object-detection": {
+            "dataset_name": [
+                "xview"
+            ],
+            "weights_file": [
+                "xview_model_state_dict_epoch_99_loss_0p67"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Partially addresses #62 -- the current download data method in Armory does not support datasets not in SUPPORTED_DATASETS (which includes adversarial datasets such as APRICOT). Also only handles weight downloads from S3, so it does not include the weight downloads embedded in the PyTorchDeepSpeech estimator.